### PR TITLE
가디언 특성(GuardianPerkType) API 요청 시 convert 로직 수정

### DIFF
--- a/src/main/java/com/momong/five_min_raid/global/common/constant/GuardianPerkType.java
+++ b/src/main/java/com/momong/five_min_raid/global/common/constant/GuardianPerkType.java
@@ -1,5 +1,9 @@
 package com.momong.five_min_raid.global.common.constant;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
 public enum GuardianPerkType {
 
     ATTACK_BERSERK,
@@ -15,5 +19,34 @@ public enum GuardianPerkType {
     DEFENSE_SHIELD,
     DEFENSE_RECOVERY,
     DEFENSE_DODGE,
-    DEFENSE_GIANT
+    DEFENSE_GIANT,
+    ;
+
+    private final String noUnderscoreName;
+
+    GuardianPerkType() {
+        this.noUnderscoreName = name().replace("_", "");
+    }
+
+    /**
+     * Enum value의 underscore를 무시한 상태로 value of 기능을 수행한다.
+     *
+     * @param value Enum value로 변환하고자 하는 문자열
+     * @return 전달받은 문자열과 일치하는 enum value
+     * @throws IllegalArgumentException 전달받은 문자열에 대해 일치하는 enum value가 없는 경우
+     */
+    @JsonCreator
+    public static GuardianPerkType ignoreUnderscoreValueOf(@Nullable String value) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalArgumentException("Invalid value: " + value);
+        }
+        value = value.replace("_", "");
+
+        for (GuardianPerkType perkType : values()) {
+            if (perkType.noUnderscoreName.equalsIgnoreCase(value)) {
+                return perkType;
+            }
+        }
+        throw new IllegalArgumentException(String.format("No matching enum constant for '%s'", value));
+    }
 }

--- a/src/main/java/com/momong/five_min_raid/global/config/WebMvcConfig.java
+++ b/src/main/java/com/momong/five_min_raid/global/config/WebMvcConfig.java
@@ -1,0 +1,15 @@
+package com.momong.five_min_raid.global.config;
+
+import com.momong.five_min_raid.global.converter.GuardianPerkTypeRequestConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new GuardianPerkTypeRequestConverter());
+    }
+}

--- a/src/main/java/com/momong/five_min_raid/global/converter/GuardianPerkTypeRequestConverter.java
+++ b/src/main/java/com/momong/five_min_raid/global/converter/GuardianPerkTypeRequestConverter.java
@@ -1,0 +1,16 @@
+package com.momong.five_min_raid.global.converter;
+
+import com.momong.five_min_raid.global.common.constant.GuardianPerkType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
+
+public class GuardianPerkTypeRequestConverter implements Converter<String, GuardianPerkType> {
+
+    @Override
+    public GuardianPerkType convert(String source) {
+        if (!StringUtils.hasText(source)) {
+            return null;
+        }
+        return GuardianPerkType.ignoreUnderscoreValueOf(source);
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #12

## 🏃‍ Task
- 언더스코어(`_`) 및 대소문자와 상관 없이 string이 enum value로 매핑되도록 custom converter 구현

## 📄 Reference
- None
